### PR TITLE
Allow infobox display in pre-fermentation stages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.21.1'
+def runeLiteVersion = '1.8.9'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/infernostats/BrewingConfig.java
+++ b/src/main/java/com/infernostats/BrewingConfig.java
@@ -7,13 +7,9 @@ import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("BrewingConfig")
 public interface BrewingConfig extends Config {
-    enum InfoBoxState {
-        COMPLETION, ALWAYS;
-    }
-
     @ConfigSection(
             name = "Infobox",
-            description = "Infobox",
+            description = "Settings relating to infoboxes",
             position = 0
     )
     String infobox = "infobox";
@@ -22,7 +18,7 @@ public interface BrewingConfig extends Config {
             position = 0,
             keyName = "keldagrimInfobox",
             name = "Keldagrim Infobox",
-            description = "Keldagrim Infobox",
+            description = "Configures whether to show the Keldagrim infobox.",
             section = infobox
     )
     default boolean keldagrimInfobox() {
@@ -33,7 +29,7 @@ public interface BrewingConfig extends Config {
             position = 1,
             keyName = "phasmatysInfobox",
             name = "Phasmatys Infobox",
-            description = "Phasmatys Infobox",
+            description = "Configures whether to show the Phasmatys infobox.",
             section = infobox
     )
     default boolean phasmatysInfobox() {
@@ -44,16 +40,16 @@ public interface BrewingConfig extends Config {
             position = 2,
             keyName = "infoboxState",
             name = "Infobox State",
-            description = "Infobox State",
+            description = "Configures when to show the infoboxes",
             section = infobox
     )
     default InfoBoxState infoboxState() {
-        return InfoBoxState.COMPLETION;
+        return InfoBoxState.PREP_OR_COMPLETED;
     }
 
     @ConfigSection(
             name = "Server",
-            description = "Server",
+            description = "Settings relating to the server",
             position = 1
     )
     String server = "server";
@@ -62,7 +58,7 @@ public interface BrewingConfig extends Config {
             position = 0,
             keyName = "sendServerData",
             name = "Send Data to Server",
-            description = "Send Brew Data to Server",
+            description = "Configures whether to send brewing data to server.",
             section = server
     )
     default boolean enableServer() {
@@ -73,7 +69,7 @@ public interface BrewingConfig extends Config {
             position = 1,
             keyName = "server",
             name = "Server URL",
-            description = "Server URL",
+            description = "Configures which URL to send the brewing data to.",
             section = server
     )
     default String server() {

--- a/src/main/java/com/infernostats/BrewingInfoBox.java
+++ b/src/main/java/com/infernostats/BrewingInfoBox.java
@@ -40,6 +40,8 @@ public class BrewingInfoBox extends InfoBox {
             else
                 return Color.GREEN;
         }
+        else if (this.brewState.prepUnfinished())
+            return Color.YELLOW;
         return Color.WHITE;
     }
 

--- a/src/main/java/com/infernostats/BrewingPlugin.java
+++ b/src/main/java/com/infernostats/BrewingPlugin.java
@@ -261,7 +261,10 @@ public class BrewingPlugin extends Plugin {
                 {
                     case ALWAYS:
                         return true;
-                    case COMPLETION:
+                    case PREP_OR_COMPLETED:
+                        BrewingState state = getConfigBrewingState(BrewingLocation.Keldagrim);
+                        return state.prepUnfinished() || state.finished();
+                    case COMPLETED:
                         return getConfigBrewingState(BrewingLocation.Keldagrim).finished();
                 }
             case Phasmatys:
@@ -271,7 +274,10 @@ public class BrewingPlugin extends Plugin {
                 {
                     case ALWAYS:
                         return true;
-                    case COMPLETION:
+                    case PREP_OR_COMPLETED:
+                        BrewingState state = getConfigBrewingState(BrewingLocation.Phasmatys);
+                        return state.prepUnfinished() || state.finished();
+                    case COMPLETED:
                         return getConfigBrewingState(BrewingLocation.Phasmatys).finished();
                 }
             default:

--- a/src/main/java/com/infernostats/BrewingState.java
+++ b/src/main/java/com/infernostats/BrewingState.java
@@ -133,6 +133,24 @@ public enum BrewingState {
         }, fromInt(this.value));
     }
 
+    public boolean prepUnfinished(){
+        return ArrayUtils.contains(new BrewingState[]{
+                WATER,
+                BARLEY,
+                HAMMERSTONE_HOPS,
+                ASGARNIAN_HOPS,
+                HARRALANDER,
+                YANILLIAN_HOPS,
+                KRANDORIAN_HOPS,
+                MUSHROOMS,
+                OAK_ROOTS,
+                CHOCOLATE_DUST,
+                WILDBLOOD_HOPS,
+                APPLE_MUSH,
+                KELDA_HOPS
+        }, fromInt(this.value));
+    }
+
     @Override
     public String toString()
     {

--- a/src/main/java/com/infernostats/BrewingState.java
+++ b/src/main/java/com/infernostats/BrewingState.java
@@ -231,7 +231,7 @@ public enum BrewingState {
             case CHEFS_DELIGHT:
                 return "Chef's Delight";
             case MATURE_CHEFS_DELIGHT:
-                return "Chef's Delight";
+                return "Mature Chef's Delight";
 
             /* Slayer's Respite */
             case WILDBLOOD_HOPS:

--- a/src/main/java/com/infernostats/InfoBoxState.java
+++ b/src/main/java/com/infernostats/InfoBoxState.java
@@ -1,0 +1,21 @@
+package com.infernostats;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum InfoBoxState
+{
+    COMPLETED("Completed"),
+    PREP_OR_COMPLETED("Prep/Completed"),
+    ALWAYS("Always");
+
+    private final String type;
+
+    @Override
+    public String toString()
+    {
+        return type;
+    }
+}


### PR DESCRIPTION
>It's been a while since my Phasmatys brew has popped. Wonder what it's doing?

![image](https://user-images.githubusercontent.com/59027738/149230083-2096ec94-8388-4907-8b88-f71af55fff7c.png)

>Ah, _fuck_.

Maybe I'm just an idiot, but I find myself teleporting away before I've added the ale yeast often enough to go make this change.

New `Prep/Completed` option to display the infobox both when your brew is finished, and when you're in the prep stages (water, barley, ingredients and apple mush), so you're aware that you didn't finish your brew prep.